### PR TITLE
Add content type header for json api requests

### DIFF
--- a/src/Message/Request/AbstractSpryngPaymentsRequest.php
+++ b/src/Message/Request/AbstractSpryngPaymentsRequest.php
@@ -156,7 +156,8 @@ abstract class AbstractSpryngPaymentsRequest extends AbstractRequest
             $method,
             $this->baseUrl . $this->apiVersion . $endpoint,
             [
-                'X-APIKEY' => $this->getApiKey()
+                'X-APIKEY'     => $this->getApiKey(),
+                'Content-Type' => 'application/json'
             ],
             ($data === null) ? null : json_encode($data)
         );


### PR DESCRIPTION
Added Content-Type application/json to request header. Without this the API does not see the request body as json and returns a missing parameter error.